### PR TITLE
Fixed compiler error

### DIFF
--- a/gzsitl/CMakeLists.txt
+++ b/gzsitl/CMakeLists.txt
@@ -25,8 +25,8 @@ set(CUSTOM_COMPILE_FLAGS "-Wall")
 set(LDFLAGS "-z noexecstack -z relro -z now")
 set(CFLAGS "-fstack-protector-all -fPIE -fPIC -O2 -D_FORTIFY_SOURCE=2")
 set(CFLAGS "${CFLAGS} -Wformat -Wformat-security")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${GAZEBO_CXX_FLAGS}")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CFLAGS} ${CUSTOM_COMPILE_FLAGS}")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${GAZEBO_CXX_FLAGS} -std=c++11")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CFLAGS} ${CUSTOM_COMPILE_FLAGS} -std=c++11")
 
 # Build Plugin
 add_library(gzsitl_plugin SHARED gzsitl_plugin.cc)


### PR DESCRIPTION
[100%] Building CXX object CMakeFiles/gzsitl_plugin.dir/gzsitl_plugin.cc.o
In file included from /usr/include/c++/4.8/thread:35:0,
                 from /home/drone/project/gazebo-sitl/gzsitl/gzsitl_plugin.hh:20,
                 from /home/drone/project/gazebo-sitl/gzsitl/gzsitl_plugin.cc:19:
/usr/include/c++/4.8/bits/c++0x_warning.h:32:2: error: #error This file requires compiler and library support for the ISO C++ 2011 standard. This support is currently experimental, and must be enabled with the -std=c++11 or -std=gnu++11 compiler options.
 #error This file requires compiler and library support for the \
