### PR TITLE
Coverity fix

### DIFF
--- a/gzsitl/gzsitl_plugin.cc
+++ b/gzsitl/gzsitl_plugin.cc
@@ -401,9 +401,11 @@ void MavServer::handle_send()
     data_to_send_access_mtx.lock();
 
     if (data_to_send_len > 0) {
-        sendto(sock, (void *)data_to_send, data_to_send_len, 0,
-               (struct sockaddr *)&remote_addr, sizeof(struct sockaddr_in));
-        data_to_send_len = 0;
+        if (sendto(sock, (void *)data_to_send, data_to_send_len, 0,
+                   (struct sockaddr *)&remote_addr,
+                   sizeof(struct sockaddr_in)) == data_to_send_len) {
+            data_to_send_len = 0;
+        }
     }
 
     data_to_send_access_mtx.unlock();

--- a/gzsitl/gzsitl_plugin.hh
+++ b/gzsitl/gzsitl_plugin.hh
@@ -75,7 +75,7 @@ class MavServer
 
     // Vehicle Communication
     int sock = 0;
-    socklen_t fromlen;
+    socklen_t fromlen = 0;
     struct sockaddr_in local_addr;
     struct sockaddr_in remote_addr;
 
@@ -129,7 +129,7 @@ class GAZEBO_VISIBLE GZSitlPlugin : public ModelPlugin
     bool is_ground_pos_locked();
 
     // Coordinates
-    mavlink_global_position_int_t init_global_pos;
+    mavlink_global_position_int_t init_global_pos = {0};
     common::SphericalCoordinates global_pos_coord_system;
 
     mavlink_global_position_int_t


### PR DESCRIPTION
From coverty check http://dronecode01.sh.intel.com/gazebo/coverity/bc1e6f1/
## 

Solve with this patch:

1   CHECKED_RETURN  /home/drone/Dronecode/Upstream/gazebo-sitl/gzsitl/gzsitl_plugin.cc  MavServer::handle_send()    Unclassified
69  UNINIT  /home/drone/Dronecode/Upstream/gazebo-sitl/gzsitl/gzsitl_plugin.cc  gazebo::GZSitlPlugin::home_pos_to_global(__mavlink_home_position_t) Unclassified
70  UNINIT_CTOR /home/drone/Dronecode/Upstream/gazebo-sitl/gzsitl/gzsitl_plugin.cc  MavServer::MavServer(short) Unclassified
71  UNINIT_CTOR /usr/include/gazebo-7/gazebo/common/Plugin.hh   gazebo::PluginTgazebo::ModelPlugin::PluginT() Unclassified
72  UNINIT_CTOR /home/drone/Dronecode/Upstream/gazebo-sitl/gzsitl/gzsitl_plugin.cc  gazebo::GZSitlPlugin::GZSitlPlugin()    Unclassified
## 

Probably solved on general-fixes pull request:

67  MISSING_ASSIGN  /home/drone/Dronecode/Upstream/gazebo-sitl/gzsitl/gzsitl_plugin.hh  unknown Unclassified
68  MISSING_COPY    /home/drone/Dronecode/Upstream/gazebo-sitl/gzsitl/gzsitl_plugin.hh  unknown Unclassified
## 

The other errors are not directly related to the gzsitl code.
