### PR TITLE
Fix missing closing bracket on handle_message

### DIFF
--- a/gzsitl/mavserver.cc
+++ b/gzsitl/mavserver.cc
@@ -433,6 +433,7 @@ void MavServer::handle_message(const mavlink_message_t *msg)
                         attitude.time_boot_ms - prev_time_att);
         return;
     }
+    }
 
     // Low Priority Messages - with global lock
     std::lock_guard<std::mutex> locker(svar_access_mtx);
@@ -463,6 +464,4 @@ void MavServer::handle_message(const mavlink_message_t *msg)
         break;
     }
     }
-}
-
 }


### PR DESCRIPTION
This fix solves issue #12.

A missing bracket was resulting in a critical block of the handle_message
switch never being reached. Before this fix, the vehicle would loop forever
waiting for those unhandled messages.

Signed-off-by: Guilherme Campos Camargo guilherme.campos.camargo@intel.com
