### PR TITLE
Set cmake DIR paths as relative

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,13 +7,13 @@ if (NOT PYTHON)
 endif()
 
 # Generate Mavlink Messages
-if(NOT EXISTS ${CMAKE_BINARY_DIR}/lib/)
+if(NOT EXISTS ${CMAKE_CURRENT_BINARY_DIR}/lib/)
     execute_process(
-            WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/modules/mavlink
+            WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/modules/mavlink
             COMMAND
             ${PYTHON}
             -m pymavlink.tools.mavgen
-            -o ${CMAKE_BINARY_DIR}/lib
+            -o ${CMAKE_CURRENT_BINARY_DIR}/lib
             --lang C
             ./message_definitions/v1.0/common.xml)
 endif()
@@ -22,8 +22,8 @@ endif()
 find_package(gazebo REQUIRED)
 include_directories(
     ${GAZEBO_INCLUDE_DIRS}
-    ${CMAKE_BINARY_DIR}/lib/common
-    ${CMAKE_BINARY_DIR}/lib)
+    ${CMAKE_CURRENT_BINARY_DIR}/lib/common
+    ${CMAKE_CURRENT_BINARY_DIR}/lib)
 link_directories(
     ${GAZEBO_LIBRARY_DIRS})
 


### PR DESCRIPTION
This is needed in order to allow this project to be included as a subdirectory in other cmake projects.

Signed-off-by: Guilherme Campos Camargo guilherme.campos.camargo@intel.com
