### PR TITLE
Fix gazebo crash on plugin destruction

### DIFF
--- a/gzsitl/gzsitl_plugin.cc
+++ b/gzsitl/gzsitl_plugin.cc
@@ -30,7 +30,6 @@ GZSitlPlugin::GZSitlPlugin()
 
 GZSitlPlugin::~GZSitlPlugin()
 {
-    event::Events::DisconnectWorldUpdateBegin(update_connection);
 }
 
 void GZSitlPlugin::OnUpdate()


### PR DESCRIPTION
Gazebo was crashing when the model associated with the plugin was deleted. The
problem was solved after removing the DisconnectWorldUpdateBegin() call on the
plugin destructor. This call is never used in any gazebo plugin and has been
made deprecated on Gazebo 8, what makes me think that it's a common source of
problems. The regular [destructor](http://osrf-distributions.s3.amazonaws.com/gazebo/api/dev/classgazebo_1_1event_1_1Events.html#a7377743aa9b027374ced09c8c6a58fad) for the update event should be used instead. Since
update_connection is a shared pointer ([UpdateConnectionPtr](https://osrf-distributions.s3.amazonaws.com/gazebo/api/dev/namespacegazebo_1_1event.html#a2d370e7ba9de036fe110e1f94a982773)), I assume no clear up
is needed.

Signed-off-by: Guilherme Campos Camargo guilherme.campos.camargo@intel.com
