### PR TITLE
Add custom install model path and change default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,10 +14,21 @@ include_directories(${GAZEBO_INCLUDE_DIRS})
 link_directories(${GAZEBO_LIBRARY_DIRS})
 
 # Custom instalation paths
-if (GZSITL_INSTALL_PATH)
-    set(GZSITL_PLUGIN_PATH ${GZSITL_INSTALL_PATH})
+if (GZSITL_PLUGIN_INSTALL_PATH)
+    GET_FILENAME_COMPONENT(GZSITL_PLUGIN_PATH ${GZSITL_PLUGIN_INSTALL_PATH} ABSOLUTE)
 else()
     set(GZSITL_PLUGIN_PATH ${GAZEBO_PLUGIN_PATH})
+endif()
+
+# Gazebo 7 does not provide a ${GAZEBO_MODEL_PATH} variable.
+# That's why we are accessing it relatively to ${GAZEBO_MEDIA_PATH}.
+# A proper ${GAZEBO_MODEL_PATH} variable might be available in Gazebo 8+.
+if (GZSITL_MODEL_INSTALL_PATH)
+    GET_FILENAME_COMPONENT(GZSITL_MODEL_PATH ${GZSITL_MODEL_INSTALL_PATH} ABSOLUTE)
+elseif(GAZEBO_MODEL_PATH)
+    set(GZSITL_MODEL_PATH ${GAZEBO_MODEL_PATH})
+else()
+    GET_FILENAME_COMPONENT(GZSITL_MODEL_PATH ${GAZEBO_MEDIA_PATH}/../models ABSOLUTE)
 endif()
 
 # Submodule includes

--- a/models/CMakeLists.txt
+++ b/models/CMakeLists.txt
@@ -1,7 +1,6 @@
 cmake_minimum_required(VERSION 2.8 FATAL_ERROR)
 
 install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/
-        DESTINATION $ENV{HOME}/.gazebo/models
-        USE_SOURCE_PERMISSIONS
+        DESTINATION ${GZSITL_MODEL_PATH}
         PATTERN "CMakeLists.txt" EXCLUDE)
 


### PR DESCRIPTION
The default model installation path has been changed to a regular install
folder, just like the plugin installation path. Previously we were installing
models as root into the user folder, what is not a good idea. Also, the user
may pass custom installation folders to cmake as follows:

cmake -D GZSITL_MODEL_INSTALL_PATH=<model_install_path> -D GZSITL_PLUGIN_INSTALL_PATH=<plugin_install_path>

Signed-off-by: Guilherme Campos Camargo guilherme.campos.camargo@intel.com
