### PR TITLE
Change default mavlink port

### DIFF
--- a/gzsitl/defines.hh
+++ b/gzsitl/defines.hh
@@ -20,7 +20,7 @@
 #define GZSITL_TARGET_MODEL_NAME "gzsitl_target"
 #define DEBUG_STATE (true)
 #define DEBUG_MAVLINK (false)
-#define MAVPROXY_PORT (14556)
+#define MAVPROXY_PORT (15556)
 #define DEFAULT_TARGET_SYSTEM_ID (1)    // Default Copter system ID
 #define DEFAULT_TARGET_COMPONENT_ID (1) // Default Copter component ID
 #define DEFAULT_SYSTEM_ID (22)          // This system ID


### PR DESCRIPTION
The default port gazebo-sitl chooses to bind to is coincidentally the same as
PX4. Since a port can't be bound twice, this will certainly cause problems when
both programs run with their defaults. This patch changes gazebo-sitl default
mavlink port in order to avoid those problems.

Signed-off-by: Guilherme Campos Camargo guilherme.campos.camargo@intel.com
