### PR TITLE
Takeoff

### DIFF
--- a/gzsitl/gzsitl_plugin.cc
+++ b/gzsitl/gzsitl_plugin.cc
@@ -103,13 +103,12 @@ void GZSitlPlugin::OnUpdate()
     status status = this->mav->get_status();
 
     // Get vehicle pose and update gazebo vehicle model
-    Pose3d curr_pose;
-    curr_pose = calculate_pose(this->mav->get_attitude(),
+    Pose3d vehicle_pose;
+    vehicle_pose = calculate_pose(this->mav->get_attitude(),
                                this->mav->get_local_position_ned());
-    model->SetWorldPose(curr_pose);
+    model->SetWorldPose(vehicle_pose);
 
     // Publish current gazebo vehicle pose
-    Pose3d vehicle_pose = model->WorldPose();
     this->vehicle_pose_pub->Publish(msgs::Convert(vehicle_pose));
 
     // Get pointer to the permanent target control model if exists

--- a/gzsitl/gzsitl_plugin.cc
+++ b/gzsitl/gzsitl_plugin.cc
@@ -175,6 +175,11 @@ void GZSitlPlugin::OnUpdate()
             break;
         }
 
+        // Wait until the vehicle is at least 1m off the ground
+        if (vehicle_pose.Pos()[2] < 1.0) {
+            break;
+        }
+
         print_debug_state("Takeoff Sucessfull.\n");
         simstate = ACTIVE_AIRBORNE;
         print_debug_state("state: ACTIVE_AIRBORNE\n");


### PR DESCRIPTION
This is a temporary solution to the takeoff issue. After close inspection, it seems that the plugin is indeed responsible for waiting until takeoff is done, so this is the right place to check for it.
The proper solution involves moving the plugin state based on the vehicle instead of the current disconnected internal state, but that requires rework of the entire plugin. Until then, this patch is enough to solve the issue.