### PR TITLE
Try to make gazebo-sitl compatible with Parrot Sphinx Gazebo 7 (libignition-math2.so.2.2.2)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ include_directories(${GAZEBO_INCLUDE_DIRS})
 link_directories(${GAZEBO_LIBRARY_DIRS})
 
 # Find ignition-math
-find_package(ignition-math3 REQUIRED)
+find_package(ignition-math2 REQUIRED)
 
 # ignition-math Include and Link directories
 include_directories(${IGNITION-MATH_INCLUDE_DIRS})

--- a/gzsitl/gzsitl_plugin.cc
+++ b/gzsitl/gzsitl_plugin.cc
@@ -112,7 +112,11 @@ void GZSitlPlugin::OnUpdate()
     this->vehicle_pose_pub->Publish(msgs::Convert(vehicle_pose));
 
     // Get pointer to the permanent target control model if exists
+# if GAZEBO_MAJOR_VERSION >= 7
+    this->perm_target = model->GetWorld()->GetModel(perm_target_name);
+# else
     this->perm_target = model->GetWorld()->ModelByName(perm_target_name);
+# endif
     this->perm_target_exists = (bool)this->perm_target;
 
     // Wait for mission target
@@ -121,8 +125,12 @@ void GZSitlPlugin::OnUpdate()
     }
 
     // Retrieve and publish current permanent target pose if target exists
-    this->perm_target_pose = this->perm_target->WorldPose();
-    this->perm_target_pose_pub->Publish(msgs::Convert(this->perm_target_pose));
+# if GAZEBO_MAJOR_VERSION >= 7
+//    this->perm_target_pose = this->perm_target->GetWorldPose();
+# else
+//    this->perm_target_pose = this->perm_target->WorldPose();
+# endif
+//    this->perm_target_pose_pub->Publish(msgs::Convert(this->perm_target_pose));
 
     // Update permanent target visualization according to the vehicle
     mavlink_vehicles::local_pos perm_targ_pos =
@@ -130,7 +138,11 @@ void GZSitlPlugin::OnUpdate()
             this->mav->get_mission_waypoint(),
             this->home_position);
     if (this->perm_target_vis =
+# if GAZEBO_MAJOR_VERSION >= 7
+            model->GetWorld()->GetModel(perm_target_vis_name)) {
+# else
             model->GetWorld()->ModelByName(perm_target_vis_name)) {
+# endif
         this->perm_target_vis->SetWorldPose(Pose3d(perm_targ_pos.y,
                     perm_targ_pos.x, -perm_targ_pos.z, 0, 0, 0));
     }
@@ -249,7 +261,11 @@ void GZSitlPlugin::Load(physics::ModelPtr m, sdf::ElementPtr sdf)
 
     // Setup Publishers
     this->node = transport::NodePtr(new transport::Node());
+# if GAZEBO_MAJOR_VERSION >= 7
+    this->node->Init(this->model->GetWorld()->GetName());
+# else
     this->node->Init(this->model->GetWorld()->Name());
+#endif
 
     this->perm_target_pose_pub = this->node->Advertise<msgs::Pose>(
         "~/" + this->model->GetName() + "/" + perm_target_pub_topic_name, 1,


### PR DESCRIPTION
Parrot Sphinx currently only supports Parrot based products. There is no reason the gazebo-sitl plugin for ArduCopter can't be added as well. Parrot uses Gazebo 7.0.1, which is actually version 7.0.0, so the current gazebo-sitl needs to be a bit more backwards compatible. 

http://developer.parrot.com/docs/sphinx/index.html

There is currently a compile error related to the Target Pose that needs fixed, the offending code is commented out in this commit so that things compile cleanly.  https://github.com/MAVProxyUser/gazebo-sitl/blob/dc8d20c531500f6d0f9a7795998ea847023dbf44/gzsitl/gzsitl_plugin.cc#L128

[ 87%] Building CXX object gzsitl/CMakeFiles/gzsitl_plugin.dir/gzsitl_plugin.cc.o
/opt/mesmer/log/gazebo-sitl/gzsitl/gzsitl_plugin.cc: In member function ‘void gazebo::GZSitlPlugin::OnUpdate()’:
/opt/mesmer/log/gazebo-sitl/gzsitl/gzsitl_plugin.cc:130:28: error: no match for ‘operator=’ (operand types are ‘ignition::math::Pose3d {aka ignition::math::Pose3<double>}’ and ‘const gazebo::math::Pose’)
     this->perm_target_pose = this->perm_target->GetWorldPose();
                            ^
/opt/mesmer/log/gazebo-sitl/gzsitl/gzsitl_plugin.cc:130:28: note: candidate is:
In file included from /usr/include/ignition/math2/ignition/math/Frustum.hh:22:0,
                 from /usr/include/ignition/math2/ignition/math.hh:7,
                 from /usr/include/sdformat-4.3/sdf/Param.hh:35,
                 from /usr/include/sdformat-4.3/sdf/Element.hh:24,
                 from /usr/include/sdformat-4.3/sdf/sdf.hh:5,
                 from /usr/local/include/gazebo-7/gazebo/common/Battery.hh:25,
                 from /usr/local/include/gazebo-7/gazebo/common/common.hh:8,
                 from /opt/mesmer/log/gazebo-sitl/gzsitl/gzsitl_plugin.hh:20,
                 from /opt/mesmer/log/gazebo-sitl/gzsitl/gzsitl_plugin.cc:20:
/usr/include/ignition/math2/ignition/math/Pose3.hh:222:25: note: ignition::math::Pose3<T>& ignition::math::Pose3<T>::operator=(const ignition::math::Pose3<T>&) [with T = double]
       public: Pose3<T> &operator=(const Pose3<T> &_pose)
                         ^
/usr/include/ignition/math2/ignition/math/Pose3.hh:222:25: note:   no known conversion for argument 1 from ‘const gazebo::math::Pose’ to ‘const ignition::math::Pose3<double>&’
make[2]: *** [gzsitl/CMakeFiles/gzsitl_plugin.dir/gzsitl_plugin.cc.o] Error 1
make[1]: *** [gzsitl/CMakeFiles/gzsitl_plugin.dir/all] Error 2
make: *** [all] Error 2

